### PR TITLE
fs.writeFile -> fs.writeFileSync

### DIFF
--- a/src/process-demo.js
+++ b/src/process-demo.js
@@ -138,7 +138,7 @@ module.exports = ({ markdownData, isBuild, noPreview, babelConfig, pxtorem }) =>
         (meta.reactRouter === 'react-router-dom' ? 'react-router-dom@4/umd/react-router-dom' : false),
     });
     const fileName = `demo-${Math.random()}.html`;
-    fs.writeFile(path.join(process.cwd(), '_site', fileName), html);
+    fs.writeFileSync(path.join(process.cwd(), '_site', fileName), html);
     markdownData.src = path.join('/', fileName);
   }
 


### PR DESCRIPTION
There is no need to call an asynchronous function right here. Also calling this function without callback cause deprecation warning when building antd ([DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated).